### PR TITLE
Default trace all engines/queries to True.

### DIFF
--- a/sqlalchemy_opentracing/__init__.py
+++ b/sqlalchemy_opentracing/__init__.py
@@ -6,7 +6,7 @@ g_tracer = None
 g_trace_all_queries = False
 g_trace_all_engines = False
 
-def init_tracing(tracer, trace_all_engines=False, trace_all_queries=False):
+def init_tracing(tracer, trace_all_engines=True, trace_all_queries=True):
     '''
     Set our global tracer.
     Tracer objects from our pyramid/flask/django libraries

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,7 +20,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_traced(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         creat = CreateTable(self.users_table)
@@ -40,7 +40,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_traced_none(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         creat = CreateTable(self.users_table)
@@ -50,7 +50,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_traced_all_queries(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer, trace_all_queries=True)
+        sqlalchemy_opentracing.init_tracing(tracer, False, trace_all_queries=True)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         creat = CreateTable(self.users_table)
@@ -61,7 +61,9 @@ class TestSQLAlchemyCore(unittest.TestCase):
     def test_traced_all_engines(self):
         # Don't register the engine explicitly.
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer, trace_all_engines=True)
+        sqlalchemy_opentracing.init_tracing(tracer,
+                                            trace_all_engines=True,
+                                            trace_all_queries=False)
 
         creat = CreateTable(self.users_table)
         sqlalchemy_opentracing.set_traced(creat)
@@ -77,7 +79,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_traced_error(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         creat = CreateTable(self.users_table)
@@ -104,7 +106,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_trace_text(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer, trace_all_queries=True)
+        sqlalchemy_opentracing.init_tracing(tracer, False, trace_all_queries=True)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         self.engine.execute('CREATE TABLE users (id INTEGER NOT NULL, name VARCHAR, PRIMARY KEY (id))')
@@ -120,7 +122,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_trace_text_error(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer, trace_all_queries=True)
+        sqlalchemy_opentracing.init_tracing(tracer, False, trace_all_queries=True)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         try:
@@ -142,7 +144,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_traced_transaction(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         creat = CreateTable(self.users_table)
@@ -165,7 +167,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_traced_transaction_nested(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         creat = CreateTable(self.users_table)
@@ -191,7 +193,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_traced_rollback(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         creat = CreateTable(self.users_table)
@@ -220,7 +222,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_traced_after_transaction(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         creat = CreateTable(self.users_table)
@@ -243,7 +245,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_traced_after_rollback(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         creat = CreateTable(self.users_table)
@@ -273,7 +275,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_traced_clear_connection(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         creat = CreateTable(self.users_table)
@@ -294,7 +296,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
 
     def test_unregister_engine(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer, trace_all_queries=True)
+        sqlalchemy_opentracing.init_tracing(tracer, False, trace_all_queries=True)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         creat = CreateTable(self.users_table)

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -26,7 +26,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
 
     def test_traced_simple(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         session = self.session
@@ -46,7 +46,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
 
     def test_traced_none(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         session = self.session
@@ -59,7 +59,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
     # test mixing insert with select and insert
     def test_traced_all(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer, trace_all_queries=True)
+        sqlalchemy_opentracing.init_tracing(tracer, False, trace_all_queries=True)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         session = self.session
@@ -74,7 +74,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
 
     def test_traced_error(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         # Don't trace this one.
@@ -104,7 +104,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
 
     def test_traced_parent(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         session = self.session
@@ -121,7 +121,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
 
     def test_traced_text(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         session = self.session
@@ -142,7 +142,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
 
     def test_traced_text_error(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         session = self.session
@@ -168,7 +168,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
 
     def test_traced_after_commit(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         session = self.session
@@ -189,7 +189,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
 
     def test_traced_after_rollback(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         session = self.session
@@ -212,7 +212,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
 
     def test_traced_commit_repeat(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         parent_span1 = DummySpan('parent1')
@@ -237,7 +237,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
     @unittest.skip('SQLite doesnt properly handle savepoints')
     def test_traced_savepoint(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         session = self.session
@@ -256,7 +256,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
 
     def test_traced_bulk_insert(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         parent_span = DummySpan('parent')
@@ -277,7 +277,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
 
     def test_traced_clear_session(self):
         tracer = DummyTracer()
-        sqlalchemy_opentracing.init_tracing(tracer)
+        sqlalchemy_opentracing.init_tracing(tracer, False, False)
         sqlalchemy_opentracing.register_engine(self.engine)
 
         session = self.session


### PR DESCRIPTION
This is done in order to improve usability - and this is
something we do now by default in other connectors/libraries.